### PR TITLE
fix: Require sessionType in addSessionMetaData

### DIFF
--- a/lib/db.dart
+++ b/lib/db.dart
@@ -109,12 +109,14 @@ class DataBase extends _$DataBase {
   void addSessionMetaData({
     required int sessionID,
     required String participantId,
+    required String sessionType,
     required DateTime timeStart,
     required DateTime timeEnd,
   }) {
     sessionData = SessionsCompanion(
       sessionID: Value(sessionID),
       participantId: Value(participantId),
+      sessionType: Value(sessionType),
       timeStart: Value(timeStart),
       timeEnd: Value(timeEnd),
     );


### PR DESCRIPTION
## Description

Fix a bug introduced in 35b9a2f because was not required in the method that creates Session objects and adds them to the db.


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
