### PR TITLE
fix: Export trialType to users

### DIFF
--- a/lib/data.dart
+++ b/lib/data.dart
@@ -1,3 +1,4 @@
 library cognitive_data;
 
 export 'package:cognitive_data/db.dart';
+export 'package:cognitive_data/trial_type.dart';


### PR DESCRIPTION
## Description

trial type must be available to caller so that it can be used to specify the trial type in the `DataBase.addTrialData`.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
