### PR TITLE
Don't declare an init abstract method in db base

### DIFF
--- a/lib/data_manager/data_manager.dart
+++ b/lib/data_manager/data_manager.dart
@@ -52,9 +52,4 @@ class DataManager implements DB {
     );
     trials.add(trial);
   }
-
-  @override
-  void initDB() {
-    // TODO: implement initDB
-  }
 }

--- a/lib/models/db_base.dart
+++ b/lib/models/db_base.dart
@@ -22,6 +22,4 @@ abstract class DB {
     required String resp,
     required TrialType trialType,
   }) {}
-
-  void initDB() {}
 }


### PR DESCRIPTION
## Description

Not all db implementations will require an init method because it is meant for cases where initiating the db requires complex logic that is best handled internally. However, dbs like the data manager only require the data manager to be instantiated so it does not make sense to have an init method.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
