### PR TITLE
improve: Convert DataManager to InMemoryDB

### DIFF
--- a/design.md
+++ b/design.md
@@ -3,7 +3,7 @@
 - add device
 - add trial 
 
-# Data manager
+# In memory db
 ## Manager 
 
 - add trial

--- a/lib/data_manager/data_manager.dart
+++ b/lib/data_manager/data_manager.dart
@@ -4,7 +4,7 @@ import 'package:cognitive_data/models/session.dart';
 import 'package:cognitive_data/models/trial.dart';
 import 'package:cognitive_data/models/trial_type.dart';
 
-class DataManager implements DB {
+class InMemoryDB implements DB {
   late final Device device;
   late final SessionMetadata sessionMetadata;
   final List<Trial> trials = <Trial>[];

--- a/test/data_manager/data_manager_test.dart
+++ b/test/data_manager/data_manager_test.dart
@@ -12,7 +12,7 @@ void main() {
       () {
     WidgetsFlutterBinding.ensureInitialized();
     final Device device = Device(participantID: '101', sessionID: '001');
-    final DataManager manager = DataManager();
+    final InMemoryDB manager = InMemoryDB();
     manager.addDevice(
         sessionID: device.sessionID, participantID: device.participantID);
 
@@ -30,7 +30,7 @@ void main() {
       endTime: DateTime.now(),
     );
 
-    final DataManager manager = DataManager();
+    final InMemoryDB manager = InMemoryDB();
     manager.addSessionMetadata(
       sessionID: metadata.sessionID,
       participantID: metadata.participantID,
@@ -53,7 +53,7 @@ void main() {
       stim: '987',
       response: '987',
     );
-    final DataManager manager = DataManager();
+    final InMemoryDB manager = InMemoryDB();
 
     manager.addTrial(
       sessionID: trial.sessionID,


### PR DESCRIPTION
## Description

The package design has changed. The data manager was originally designed to provide the only interface for users serving as a in-memory db and a data manager that interacted with other specific dbs (e.g.,  drift). In the current design the data manager will only serve as an in-memory db and was renamed accordingly. The package will provide the specific dbs to the user to use as needed.

The in-memory db is kept given and there are cases when data will not be saved/persisted unless the participant completes all trial or other similar criteria. In conditions such as these, when critera are met the user can then choose to pass the data from the in-memory db to drift by extracting it or pass the data directly into the drift db.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
