### PR TITLE
Implement method to add session metadata to the drift db

### DIFF
--- a/lib/databases/drift_db/drift_db.dart
+++ b/lib/databases/drift_db/drift_db.dart
@@ -26,6 +26,8 @@ class DriftDB extends _$DriftDB implements DB {
     return id;
   }
 
+  /// Adds the metadata from a single Session object to the drift db.
+  /// Requires a base [SessionMetadata] object as param.
   @override
   Future<int> addSessionMetadata({required SessionMetadata session}) async {
     final DriftSessionMetadataCompanion sessionMetadataCompanion =

--- a/lib/databases/drift_db/drift_db.dart
+++ b/lib/databases/drift_db/drift_db.dart
@@ -27,8 +27,13 @@ class DriftDB extends _$DriftDB implements DB {
   }
 
   @override
-  void addSessionMetadata({required SessionMetadata session}) {
-    // TODO: implement addSessionMetadata
+  Future<int> addSessionMetadata({required SessionMetadata session}) async {
+    final DriftSessionMetadataCompanion sessionMetadataCompanion =
+        DriftSessionMetadata.fromSessionMetadata(session);
+    final int id =
+        await into(driftSessionMetadata).insert(sessionMetadataCompanion);
+
+    return id;
   }
 
   /// Adds a single trial to the drift db from a base [Trial] object.

--- a/test/databases/drift_db/drift_db_test.dart
+++ b/test/databases/drift_db/drift_db_test.dart
@@ -1,5 +1,6 @@
 import 'package:cognitive_data/databases/drift_db/drift_db.dart';
 import 'package:cognitive_data/models/device.dart';
+import 'package:cognitive_data/models/session.dart';
 import 'package:cognitive_data/models/trial.dart';
 import 'package:cognitive_data/models/trial_type.dart';
 import 'package:drift/native.dart';
@@ -58,6 +59,37 @@ void main() {
       expect(driftDevice.height, baseDevice.height);
       expect(driftDevice.width, baseDevice.width);
       expect(driftDevice.aspectRatio, baseDevice.aspectRatio);
+    },
+  );
+
+  test(
+    "Drift.addSession inserts a session into the DriftDB with appropriate data fields",
+    () async {
+      final SessionMetadata baseSession = SessionMetadata(
+        participantID: '101',
+        sessionID: '001',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
+      );
+
+      await db.addSessionMetadata(session: baseSession);
+
+      final DriftSessionMetadataData driftSession =
+          await db.select(db.driftSessionMetadata).getSingle();
+
+      expect(driftSession.participantID, baseSession.participantID);
+      expect(driftSession.sessionID, baseSession.sessionID);
+
+      /// Drift truncates milliseconds so we accept less than 1s differences
+      /// between the actual and expected.
+      const Duration tolerance = Duration(seconds: 1);
+      final Duration differenceStartTime =
+          driftSession.startTime.difference(baseSession.startTime);
+      expect(differenceStartTime, lessThan(tolerance));
+
+      final Duration differenceEndTime =
+          driftSession.endTime.difference(baseSession.startTime);
+      expect(differenceEndTime, lessThan(tolerance));
     },
   );
 }


### PR DESCRIPTION
## Description

Adds the data from a single device object into the drift db using a base Device model as parameter. Includes tests and docstrings.

## Related Issue

<!-- If your PR refers to a related issue, link it here using `fix #[number-of-issue]`. -->
<!-- If this is not related to an issue, please delete this section (`Related Issue`). -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
