### PR TITLE
Implement method to facilitate init a DriftDB

### DIFF
--- a/lib/databases/drift_db/drift_db.dart
+++ b/lib/databases/drift_db/drift_db.dart
@@ -24,7 +24,7 @@ class DriftDB extends _$DriftDB implements DB {
   /// This static method is meant to be used as a constructor to make it
   /// easier for users to init a [DriftDB]. Instantiate the [DriftDB] directly
   /// if you need more flexibility.
-  static Future<DriftDB> init({required String path}) async {
+  static DriftDB init({required String path}) {
     final file = File(path);
 
     LazyDatabase nativeDB = LazyDatabase(() async {

--- a/lib/databases/drift_db/drift_db.dart
+++ b/lib/databases/drift_db/drift_db.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cognitive_data/databases/drift_db/models/device.dart';
 import 'package:cognitive_data/databases/drift_db/models/session.dart';
 import 'package:cognitive_data/databases/drift_db/models/trial.dart';
@@ -5,6 +7,7 @@ import 'package:cognitive_data/models/trial.dart';
 import 'package:cognitive_data/models/session.dart';
 import 'package:cognitive_data/models/device.dart';
 import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
 
 import '../../models/db_base.dart';
 
@@ -16,6 +19,17 @@ class DriftDB extends _$DriftDB implements DB {
 
   @override
   int get schemaVersion => 1;
+
+  static Future<DriftDB> init({required String path}) async {
+    final file = File(path);
+
+    LazyDatabase nativeDB = LazyDatabase(() async {
+      return NativeDatabase(file);
+    });
+
+    final DriftDB db = DriftDB(nativeDB);
+    return db;
+  }
 
   /// Adds the data from a single device object to the drift.
   /// Requires a base [Device] object as param.

--- a/lib/databases/drift_db/drift_db.dart
+++ b/lib/databases/drift_db/drift_db.dart
@@ -20,6 +20,10 @@ class DriftDB extends _$DriftDB implements DB {
   @override
   int get schemaVersion => 1;
 
+  /// Initialize a [DriftDB] in the provided [path] and return it.
+  /// This static method is meant to be used as a constructor to make it
+  /// easier for users to init a [DriftDB]. Instantiate the [DriftDB] directly
+  /// if you need more flexibility.
   static Future<DriftDB> init({required String path}) async {
     final file = File(path);
 

--- a/test/databases/drift_db/drift_db_test.dart
+++ b/test/databases/drift_db/drift_db_test.dart
@@ -94,6 +94,23 @@ void main() {
       expect(differenceEndTime, lessThan(tolerance));
     },
   );
+  group(
+    "DriftDB.init",
+    () {
+      late Directory tempDir;
+      late DriftDB db;
+
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp('test_dir');
+        final String path = "${tempDir.path}/cognitive_data_test.sqlite";
+        db = await DriftDB.init(path: path);
+      });
+
+      tearDown(() async {
+        await db.close();
+        await tempDir.delete(recursive: true);
+      });
+
       test(
         "Returns a drift NativeDatabase that contains at least 1 table",
         () {

--- a/test/databases/drift_db/drift_db_test.dart
+++ b/test/databases/drift_db/drift_db_test.dart
@@ -98,23 +98,23 @@ void main() {
     "DriftDB.init",
     () {
       late Directory tempDir;
-      late DriftDB db;
+      late DriftDB tempDB;
 
       setUp(() async {
         tempDir = await Directory.systemTemp.createTemp('test_dir');
         final String path = "${tempDir.path}/cognitive_data_test.sqlite";
-        db = await DriftDB.init(path: path);
+        tempDB = DriftDB.init(path: path);
       });
 
       tearDown(() async {
-        await db.close();
+        await tempDB.close();
         await tempDir.delete(recursive: true);
       });
 
       test(
         "Returns a drift NativeDatabase that contains at least 1 table",
         () {
-          final int numberOfTables = db.allTables.toList().length;
+          final int numberOfTables = tempDB.allTables.toList().length;
           expect(numberOfTables, greaterThan(0));
         },
       );

--- a/test/databases/drift_db/drift_db_test.dart
+++ b/test/databases/drift_db/drift_db_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cognitive_data/databases/drift_db/drift_db.dart';
 import 'package:cognitive_data/models/device.dart';
 import 'package:cognitive_data/models/session.dart';
@@ -7,7 +9,7 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  late final DriftDB db;
+  late DriftDB db;
 
   setUp(() {
     db = DriftDB(NativeDatabase.memory());
@@ -90,6 +92,15 @@ void main() {
       final Duration differenceEndTime =
           driftSession.endTime.difference(baseSession.startTime);
       expect(differenceEndTime, lessThan(tolerance));
+    },
+  );
+      test(
+        "Returns a drift NativeDatabase that contains at least 1 table",
+        () {
+          final int numberOfTables = db.allTables.toList().length;
+          expect(numberOfTables, greaterThan(0));
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
## Description

DriftDB.init is provided as a static method that serves as a constructor to make it easier for users to init a DriftDB in the path provided by the user.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->