### PR TITLE
refactor: Make drift table/model names plural

### DIFF
--- a/lib/databases/drift_db/drift_db.dart
+++ b/lib/databases/drift_db/drift_db.dart
@@ -13,7 +13,7 @@ import '../../models/db_base.dart';
 
 part 'drift_db.g.dart';
 
-@DriftDatabase(tables: [DriftSessionMetadata, DriftDevice, DriftTrial])
+@DriftDatabase(tables: [DriftSessionMetadata, DriftDevices, DriftTrials])
 class DriftDB extends _$DriftDB implements DB {
   DriftDB(QueryExecutor dbConnection) : super(dbConnection);
 
@@ -39,7 +39,8 @@ class DriftDB extends _$DriftDB implements DB {
   /// Requires a base [Device] object as param.
   @override
   Future<int> addDevice({required Device device}) async {
-    final DriftDeviceCompanion deviceCompanion = DriftDevice.fromDevice(device);
+    final DriftDeviceCompanion deviceCompanion =
+        DriftDevices.fromDevice(device);
     final int id = await into(driftDevice).insert(deviceCompanion);
     return id;
   }
@@ -59,7 +60,7 @@ class DriftDB extends _$DriftDB implements DB {
   /// Adds a single trial to the drift db from a base [Trial] object.
   @override
   Future<int> addTrial({required Trial trial}) async {
-    final DriftTrialCompanion trialCompanion = DriftTrial.fromTrial(trial);
+    final DriftTrialCompanion trialCompanion = DriftTrials.fromTrial(trial);
     final int id = await into(driftTrial).insert(trialCompanion);
     return id;
   }

--- a/lib/databases/drift_db/drift_db.g.dart
+++ b/lib/databases/drift_db/drift_db.g.dart
@@ -551,7 +551,7 @@ class DriftDeviceCompanion extends UpdateCompanion<DriftDeviceData> {
   }
 }
 
-class $DriftDeviceTable extends DriftDevice
+class $DriftDeviceTable extends DriftDevices
     with TableInfo<$DriftDeviceTable, DriftDeviceData> {
   @override
   final GeneratedDatabase attachedDatabase;
@@ -899,7 +899,7 @@ class DriftTrialCompanion extends UpdateCompanion<DriftTrialData> {
   }
 }
 
-class $DriftTrialTable extends DriftTrial
+class $DriftTrialTable extends DriftTrials
     with TableInfo<$DriftTrialTable, DriftTrialData> {
   @override
   final GeneratedDatabase attachedDatabase;

--- a/lib/databases/drift_db/models/device.dart
+++ b/lib/databases/drift_db/models/device.dart
@@ -7,7 +7,7 @@ import '../../../models/device.dart';
 /// Drift table analogous to the base [Device] model. It contains the same data
 /// and can be easily instantiated from a base [Device] model. See the
 /// base [Device] model for details.
-class DriftDevice extends Table {
+class DriftDevices extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get participantID =>
       text().references(DriftSessionMetadata, #participantID)();

--- a/lib/databases/drift_db/models/trial.dart
+++ b/lib/databases/drift_db/models/trial.dart
@@ -6,7 +6,7 @@ import 'package:drift/drift.dart';
 /// Drift table analogous to the base [Trial] model. It contains the same data
 /// and can be easily instantiated from a base [Trial] model. See the
 /// base [Trial] model for details.
-class DriftTrial extends Table {
+class DriftTrials extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get participantID =>
       text().references(DriftSessionMetadata, #participantID)();

--- a/test/databases/drift_db/models/device_test.dart
+++ b/test/databases/drift_db/models/device_test.dart
@@ -26,7 +26,7 @@ void main() {
       );
 
       final DriftDeviceCompanion driftDevice =
-          DriftDevice.fromDevice(baseDevice);
+          DriftDevices.fromDevice(baseDevice);
 
       expect(driftDevice.participantID.value, baseDevice.participantID);
       expect(driftDevice.sessionID.value, baseDevice.sessionID);

--- a/test/databases/drift_db/models/trial_test.dart
+++ b/test/databases/drift_db/models/trial_test.dart
@@ -26,7 +26,7 @@ void main() {
         stim: '456',
         response: '654');
 
-    final DriftTrialCompanion driftTrial = DriftTrial.fromTrial(baseTrial);
+    final DriftTrialCompanion driftTrial = DriftTrials.fromTrial(baseTrial);
 
     expect(driftTrial.participantID.value, baseTrial.participantID);
     expect(driftTrial.sessionID.value, baseTrial.sessionID);


### PR DESCRIPTION
## Description

This change follows the cannonical form for naming tables in drift.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
