### PR TITLE
Add method for initializing the firebase db

### DIFF
--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -13,8 +13,9 @@ class FirebaseDB implements DB {
 
   /// Initialize the db.
   /// Must be run before using the FirebaseDB.
-  void init() {
-    _db = FirebaseFirestore.instance;
+  static FirebaseDB init() {
+    final FirebaseDB db = FirebaseDB(FirebaseFirestore.instance);
+    return db;
   }
 
   @override

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -7,6 +7,11 @@ import 'package:cognitive_data/models/device.dart';
 /// DB used to store data in Firebase.
 class FirebaseDB implements DB {
   late final FirebaseFirestore _db;
+
+  void init() {
+    _db = FirebaseFirestore.instance;
+  }
+
   @override
   void addDevice({required Device device}) {
     // TODO: implement addDevice

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -8,6 +8,8 @@ import 'package:cognitive_data/models/device.dart';
 class FirebaseDB implements DB {
   late final FirebaseFirestore _db;
 
+  /// Initialize the db.
+  /// Must be run before using the FirebaseDB.
   void init() {
     _db = FirebaseFirestore.instance;
   }

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -5,8 +5,11 @@ import 'package:cognitive_data/models/session.dart';
 import 'package:cognitive_data/models/device.dart';
 
 /// DB used to store data in Firebase.
+/// Requires passing a [FirebaseFirestore] instance at instantiation.
 class FirebaseDB implements DB {
   late final FirebaseFirestore _db;
+
+  FirebaseDB(this._db);
 
   /// Initialize the db.
   /// Must be run before using the FirebaseDB.

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cognitive_data/models/db_base.dart';
 import 'package:cognitive_data/models/trial.dart';
 import 'package:cognitive_data/models/session.dart';
@@ -5,6 +6,7 @@ import 'package:cognitive_data/models/device.dart';
 
 /// DB used to store data in Firebase.
 class FirebaseDB implements DB {
+  late final FirebaseFirestore _db;
   @override
   void addDevice({required Device device}) {
     // TODO: implement addDevice


### PR DESCRIPTION
## Description

FirebaseDB now includes a private field that references the firebase db and an init method.

init() is not being tested because the only meaningful way of testing would require adding to a collection or actually using it.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
