### PR TITLE
Add functionality to save device metadata to firebase

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cognitive_data/databases/firebase_db/firebase_db.dart';
+import 'package:cognitive_data/models/device.dart';
 import 'package:cognitive_data/models/session.dart';
 import 'package:flutter/material.dart';
 
@@ -65,7 +66,11 @@ class MyHomePage extends StatelessWidget {
               child: const Text("Save Session metadata to firebase"),
             ),
             ElevatedButton(
-              onPressed: () {},
+              onPressed: () async {
+                final Device device =
+                    Device(participantID: '101', sessionID: '001');
+                await _db.addDevice(device: device);
+              },
               child: const Text("Save Device metadata to firebase"),
             ),
             ElevatedButton(

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -40,6 +40,12 @@ class FirebaseDB implements DB {
     return db;
   }
 
+  /// Adds [device] metadata to [FirebaseFirestore].
+  ///
+  /// It will override any device metadata previously saved for the current
+  /// session. The current device is determined based on the [participantID],
+  /// [sessionID], and [taskName] specified when the [FirebaseDB] was
+  /// instantiated, and not from the values in [device].
   @override
   Future<void> addDevice({required Device device}) async {
     final Map<String, dynamic> deviceData = {

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -41,8 +41,23 @@ class FirebaseDB implements DB {
   }
 
   @override
-  void addDevice({required Device device}) {
-    // TODO: implement addDevice
+  Future<void> addDevice({required Device device}) async {
+    final Map<String, dynamic> deviceData = {
+      'participantID': device.participantID,
+      'sessionID': device.sessionID,
+      'height': device.height,
+      'width': device.width,
+      'aspectRatio': device.aspectRatio,
+      'platform': device.platform,
+    };
+
+    final DocumentReference sessionRef = _db.doc(
+        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID');
+
+    await sessionRef.set(
+      {'deviceMetadata': deviceData},
+      SetOptions(merge: true),
+    );
   }
 
   /// Adds metadata for the [session] to [FirebaseFirestore].


### PR DESCRIPTION
## Description

- Implements FirebaseDB.addDevice()
- Overrides deviceMetadata already in the doc
- FirebaseDB.addDevice merges device metadata with Firebase; doesn't override sessionMetadata nor trials
- Example app uses this new functionality

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
