### PR TITLE
Fix: Store session metadata in firebase field and don't override other fields

### DIFF
--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -74,15 +74,16 @@ class FirebaseDB implements DB {
   /// from the values in [session].
   @override
   Future<void> addSession({required Session session}) async {
-    final CollectionReference dataRef = _db.collection(
-        'participants/$participantID/cognitive_tasks/$taskName/sessions');
-
     final Map<String, dynamic> sessionData = {
       'participantID': session.participantID,
       'sessionID': session.sessionID,
       'startTime': session.startTime.toString(),
       'endTime': session.endTime.toString(),
     };
+
+    final CollectionReference dataRef = _db.collection(
+        'participants/$participantID/cognitive_tasks/$taskName/sessions');
+
     await dataRef.doc(sessionID).set(
       {'sessionMetadata': sessionData},
       SetOptions(merge: true),

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -83,7 +83,10 @@ class FirebaseDB implements DB {
       'startTime': session.startTime.toString(),
       'endTime': session.endTime.toString(),
     };
-    await dataRef.doc(sessionID).set({'sessionMetadata': sessionData});
+    await dataRef.doc(sessionID).set(
+      {'sessionMetadata': sessionData},
+      SetOptions(merge: true),
+    );
   }
 
   @override

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -77,12 +77,13 @@ class FirebaseDB implements DB {
     final CollectionReference dataRef = _db.collection(
         'participants/$participantID/cognitive_tasks/$taskName/sessions');
 
-    await dataRef.doc(sessionID).set({
+    final Map<String, dynamic> sessionData = {
       'participantID': session.participantID,
       'sessionID': session.sessionID,
       'startTime': session.startTime.toString(),
       'endTime': session.endTime.toString(),
-    });
+    };
+    await dataRef.doc(sessionID).set({'sessionMetadata': sessionData});
   }
 
   @override

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -81,10 +81,10 @@ class FirebaseDB implements DB {
       'endTime': session.endTime.toString(),
     };
 
-    final CollectionReference dataRef = _db.collection(
-        'participants/$participantID/cognitive_tasks/$taskName/sessions');
+    final DocumentReference sessionRef = _db.doc(
+        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID');
 
-    await dataRef.doc(sessionID).set(
+    await sessionRef.set(
       {'sessionMetadata': sessionData},
       SetOptions(merge: true),
     );


### PR DESCRIPTION
## Description

Fixes a 2 bugs that were introduced when FirebaseDB.addSession() was implemented.
- Now the session metadata is stored in a firebase field named sessionMetadata. 
- Other fields are not overriden (e.g., deviceMetadata)

Also includes some minor refactoring to improve readability.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
