### PR TITLE
Store firebase data into subcollections inside session

### DIFF
--- a/design.md
+++ b/design.md
@@ -66,7 +66,13 @@ The data will be organized in the following manner:
       - document: taskID
         - field: taskID
         - collection: sessions
-          - document: sessionID
-            - field: sessionMetadata {map}
-            - field: deviceMetadata {map}
-            - field: trials [array {map}]
+          - document: sessionID 
+            - collection: sessionMetadata
+              - document: sessionMetadata
+                - fields
+            - collection: deviceMetadata
+              - document: deviceMetadata
+                - fields
+            - collection: trials
+              - document: firebase_auto_generated_id
+                - fields

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -57,13 +57,10 @@ class FirebaseDB implements DB {
       'platform': device.platform,
     };
 
-    final DocumentReference sessionRef = _db.doc(
-        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID');
+    final CollectionReference deviceRef = _db.collection(
+        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/deviceMetadata');
 
-    await sessionRef.set(
-      {'deviceMetadata': deviceData},
-      SetOptions(merge: true),
-    );
+    await deviceRef.add(deviceData);
   }
 
   /// Adds metadata for the [session] to [FirebaseFirestore].

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -62,11 +62,9 @@ class FirebaseDB implements DB {
   }
 
   /// Adds metadata for the [session] to [FirebaseFirestore].
-  ///
-  /// It will override any data previously saved for the current session. The
-  /// current session is determined based on the [participantID], [sessionID],
-  /// and [taskName] specified when the [FirebaseDB] was instantiated, and not
-  /// from the values in [session].
+  /// Stores the [session] metadata in independent docs inside a collection
+  /// named `sessionMetadata`. It will override previous [session] metadata for
+  /// the session.
   @override
   Future<void> addSession({required Session session}) async {
     final Map<String, dynamic> sessionData = {

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -41,11 +41,9 @@ class FirebaseDB implements DB {
   }
 
   /// Adds [device] metadata to [FirebaseFirestore].
-  ///
-  /// It will override any device metadata previously saved for the current
-  /// session. The current device is determined based on the [participantID],
-  /// [sessionID], and [taskName] specified when the [FirebaseDB] was
-  /// instantiated, and not from the values in [device].
+  /// Stores the [device] metadata in an independent doc inside a collection
+  /// named `deviceMetadata`. It will override previous [device] metadata for
+  /// the session.
   @override
   Future<void> addDevice({required Device device}) async {
     final Map<String, dynamic> deviceData = {

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -60,7 +60,7 @@ class FirebaseDB implements DB {
     final CollectionReference deviceRef = _db.collection(
         'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/deviceMetadata');
 
-    await deviceRef.add(deviceData);
+    await deviceRef.doc('deviceMetadata').set(deviceData);
   }
 
   /// Adds metadata for the [session] to [FirebaseFirestore].

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -76,13 +76,10 @@ class FirebaseDB implements DB {
       'endTime': session.endTime.toString(),
     };
 
-    final DocumentReference sessionRef = _db.doc(
-        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID');
+    final CollectionReference sessionRef = _db.collection(
+        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/sessionMetadata');
 
-    await sessionRef.set(
-      {'sessionMetadata': sessionData},
-      SetOptions(merge: true),
-    );
+    await sessionRef.add(sessionData);
   }
 
   @override

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -79,7 +79,7 @@ class FirebaseDB implements DB {
     final CollectionReference sessionRef = _db.collection(
         'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/sessionMetadata');
 
-    await sessionRef.add(sessionData);
+    await sessionRef.doc('sessionMetadata').set(sessionData);
   }
 
   @override


### PR DESCRIPTION
## Description

Device and session metadata are now stored into separate docs in dedicated subcollections. 

Thes changes improve code maintainability, protect data integrity (e.g., being overriden), and make it easier to convert back into data models used by `cognitive_tasks`.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
