### PR TITLE
Implement Firebase functionality to save data from a single trial

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cognitive_data/databases/firebase_db/firebase_db.dart';
 import 'package:cognitive_data/models/device.dart';
 import 'package:cognitive_data/models/session.dart';
+import 'package:cognitive_data/models/trial.dart';
+import 'package:cognitive_data/models/trial_type.dart';
 import 'package:flutter/material.dart';
 
 import 'package:firebase_core/firebase_core.dart';
@@ -74,7 +76,17 @@ class MyHomePage extends StatelessWidget {
               child: const Text("Save Device metadata to firebase"),
             ),
             ElevatedButton(
-              onPressed: () {},
+              onPressed: () async {
+                final Trial trial = Trial(
+                  participantID: _db.participantID,
+                  sessionID: _db.sessionID,
+                  trialType: TrialType.practice,
+                  stim: '123',
+                  response: '321',
+                );
+
+                await _db.addTrial(trial: trial);
+              },
               child: const Text("Save trial to firebase"),
             ),
             ElevatedButton(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,7 +34,7 @@ class MyHomePage extends StatelessWidget {
   final String title;
   final _db = FirebaseDB(
     FirebaseFirestore.instance,
-    participantID: '101,',
+    participantID: '101',
     sessionID: '001',
     taskName: 'dsb',
   );

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -81,8 +81,19 @@ class FirebaseDB implements DB {
   }
 
   @override
-  void addTrial({required Trial trial}) {
-    // TODO: implement addTrial
+  Future<void> addTrial({required Trial trial}) async {
+    final Map<String, dynamic> trialMap = {
+      'participantID': trial.participantID,
+      'sessionID': trial.sessionID,
+      'trialType': trial.trialType,
+      'stim': trial.stim,
+      'response': trial.response,
+    };
+
+    final CollectionReference trialsRef = _db.collection(
+        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/trials');
+
+    await trialsRef.add(trialMap);
   }
 
   @override

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -80,6 +80,9 @@ class FirebaseDB implements DB {
     await sessionRef.doc('sessionMetadata').set(sessionData);
   }
 
+  /// Adds a single [trial] to [FirebaseFirestore].
+  /// Stores each [trial] data in an independent doc inside a collection
+  /// named `trials`.
   @override
   Future<void> addTrial({required Trial trial}) async {
     final Map<String, dynamic> trialMap = {


### PR DESCRIPTION
## Description

Saves data from a single trial into firebase. Each trial is saved in a separate document inside a `trials` collection.

Included in the example app for demo.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
