### PR TITLE
refactor: Remove FirebaseDB.init

### DIFF
--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -19,27 +19,6 @@ class FirebaseDB implements DB {
     required this.taskName,
   });
 
-  /// Initializes the db with data required by all methods.
-  /// Behaves as a constructor to facilitate [FirebaseDB] usage. The params
-  /// [participantID], [sessionID], and [taskID] are used by methods to
-  /// interact with the db since data is structured hierarchically.
-  /// [firebaseFirestore] has to be an instance of [FirebaseFirestore],
-  /// e.g., FirebaseFirestore.instance.
-  static FirebaseDB init(
-    FirebaseFirestore firebaseFirestore, {
-    required participantID,
-    required sessionID,
-    required taskID,
-  }) {
-    final FirebaseDB db = FirebaseDB(
-      firebaseFirestore,
-      participantID: participantID,
-      sessionID: sessionID,
-      taskName: taskID,
-    );
-    return db;
-  }
-
   /// Adds [device] metadata to [FirebaseFirestore].
   /// Stores the [device] metadata in an independent doc inside a collection
   /// named `deviceMetadata`. It will override previous [device] metadata for


### PR DESCRIPTION
## Description

This method is not needed since initializing the FirebaseDB is a simple process.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
