### PR TITLE
Add functionality for automatically converting base models to json (Map<String, dynamic>)

### DIFF
--- a/lib/models/device.dart
+++ b/lib/models/device.dart
@@ -1,9 +1,13 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'device.g.dart';
 
 /// Represents the characteristics of the device on which the data
 /// was collected. It serves as metadata about the data collected.
+@JsonSerializable()
 class Device {
   /// Unique identifier for the participant
   final String participantID;
@@ -46,4 +50,9 @@ class Device {
         "platform: $platform, height: $height, width: $width, "
         "aspectRatio: $aspectRatio)";
   }
+
+  /// Convert the [Device] object to its json representation.
+  /// This method is particularly useful when uploading data to Firebase and
+  /// similar no-sql dbs.
+  Map<String, dynamic> toJson() => _$DeviceToJson(this);
 }

--- a/lib/models/device.g.dart
+++ b/lib/models/device.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'device.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Device _$DeviceFromJson(Map<String, dynamic> json) => Device(
+      participantID: json['participantID'] as String,
+      sessionID: json['sessionID'] as String,
+    )
+      ..platform = json['platform'] as String
+      ..height = (json['height'] as num).toDouble()
+      ..width = (json['width'] as num).toDouble()
+      ..aspectRatio = (json['aspectRatio'] as num).toDouble();
+
+Map<String, dynamic> _$DeviceToJson(Device instance) => <String, dynamic>{
+      'participantID': instance.participantID,
+      'sessionID': instance.sessionID,
+      'platform': instance.platform,
+      'height': instance.height,
+      'width': instance.width,
+      'aspectRatio': instance.aspectRatio,
+    };

--- a/lib/models/session.dart
+++ b/lib/models/session.dart
@@ -1,4 +1,9 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'session.g.dart';
+
 /// Represents the metadata for data collection session.
+@JsonSerializable()
 class Session {
   /// Unique identifier for the participant
   final String participantID;
@@ -24,4 +29,9 @@ class Session {
     return "Session(participantID: $participantID, sessionID: $sessionID, "
         "startTime: $startTime, endTime: $endTime)";
   }
+
+  /// Convert the [Session] object to its json representation.
+  /// This method is particularly useful when uploading data to Firebase and
+  /// similar no-sql dbs.
+  Map<String, dynamic> toJson() => _$SessionToJson(this);
 }

--- a/lib/models/session.g.dart
+++ b/lib/models/session.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'session.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Session _$SessionFromJson(Map<String, dynamic> json) => Session(
+      participantID: json['participantID'] as String,
+      sessionID: json['sessionID'] as String,
+      startTime: DateTime.parse(json['startTime'] as String),
+      endTime: DateTime.parse(json['endTime'] as String),
+    );
+
+Map<String, dynamic> _$SessionToJson(Session instance) => <String, dynamic>{
+      'participantID': instance.participantID,
+      'sessionID': instance.sessionID,
+      'startTime': instance.startTime.toIso8601String(),
+      'endTime': instance.endTime.toIso8601String(),
+    };

--- a/lib/models/trial.dart
+++ b/lib/models/trial.dart
@@ -1,6 +1,11 @@
+import 'package:json_annotation/json_annotation.dart';
+
 import 'trial_type.dart';
 
+part 'trial.g.dart';
+
 /// Represents the data of a single trial.
+@JsonSerializable()
 class Trial {
   /// Unique identifier for the participant
   final String participantID;
@@ -34,4 +39,9 @@ class Trial {
     return "Trial(participantID: $participantID, sessionID: $sessionID, "
         "trialType: $trialType, stim: $stim, response: $response)";
   }
+
+  /// Convert the [Trial] object to its json representation.
+  /// This method is particularly useful when uploading data to Firebase and
+  /// similar no-sql dbs.
+  Map<String, dynamic> toJson() => _$TrialToJson(this);
 }

--- a/lib/models/trial.g.dart
+++ b/lib/models/trial.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'trial.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Trial _$TrialFromJson(Map<String, dynamic> json) => Trial(
+      participantID: json['participantID'] as String,
+      sessionID: json['sessionID'] as String,
+      trialType: $enumDecode(_$TrialTypeEnumMap, json['trialType']),
+      stim: json['stim'] as String,
+      response: json['response'] as String,
+    );
+
+Map<String, dynamic> _$TrialToJson(Trial instance) => <String, dynamic>{
+      'participantID': instance.participantID,
+      'sessionID': instance.sessionID,
+      'trialType': instance.trialType,
+      'stim': instance.stim,
+      'response': instance.response,
+    };
+
+const _$TrialTypeEnumMap = {
+  TrialType.practice: 'practice',
+  TrialType.experimental: 'experimental',
+};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.0
   firebase_core: ^2.8.0
   cloud_firestore: ^4.4.5
+  json_annotation: ^4.8.1
 
 dev_dependencies:
   flutter_test:
@@ -22,6 +23,7 @@ dev_dependencies:
   drift_dev: ^2.16.0
   build_runner: ^2.1.11
   test: ^1.21.1
+  json_serializable: ^6.7.1
   # fake_cloud_firestore: ^2.1.0
 
 flutter:

--- a/test/models/device_test.dart
+++ b/test/models/device_test.dart
@@ -13,4 +13,15 @@ void main() {
 
     expect(device.toString(), strRep);
   });
+
+  test(
+    "Device.toJson returns a valid json representation",
+    () {
+      final Device device = Device(participantID: '101', sessionID: '001');
+
+      final Map<String, dynamic> deviceJson = device.toJson();
+
+      expect(deviceJson, isMap);
+    },
+  );
 }

--- a/test/models/session_test.dart
+++ b/test/models/session_test.dart
@@ -15,4 +15,20 @@ void main() {
         "endTime: ${session.endTime})";
     expect(session.toString(), strRep);
   });
+
+  test(
+    "Session.toJson() returns a valid json representation",
+    () {
+      final Session session = Session(
+        participantID: '101',
+        sessionID: '001',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
+      );
+
+      final Map<String, dynamic> sessionJson = session.toJson();
+
+      expect(sessionJson, isMap);
+    },
+  );
 }

--- a/test/models/trial_test.dart
+++ b/test/models/trial_test.dart
@@ -17,4 +17,21 @@ void main() {
         "response: ${trial.response})";
     expect(trial.toString(), strRep);
   });
+
+  test(
+    "Trial.toJson returns a valid json representation",
+    () {
+      final Trial trial = Trial(
+        participantID: '101',
+        sessionID: '001',
+        trialType: TrialType.practice,
+        stim: 'stimuli',
+        response: 'participant response',
+      );
+
+      final Map<String, dynamic> trialJson = trial.toJson();
+
+      expect(trialJson, isMap);
+    },
+  );
 }


### PR DESCRIPTION
## Description

Adds a toJson() to Trial, Session, Device base models. It includes docstrings and unit tests for these methods. The methods are implemented by the json_serializable package (google).

## Related Issue

Closes  #70

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
