### PR TITLE
Restructure data in firebase to prioritize the specific cognitive task

### DIFF
--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -28,7 +28,7 @@ class FirebaseDB implements DB {
     final Map<String, dynamic> deviceData = device.toJson();
 
     final CollectionReference deviceRef = db.collection(
-        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/deviceMetadata');
+        'participants/$participantID/cognitive_measures/$taskName/sessions/$sessionID/deviceMetadata');
 
     await deviceRef.doc('deviceMetadata').set(deviceData);
   }
@@ -42,7 +42,7 @@ class FirebaseDB implements DB {
     final Map<String, dynamic> sessionData = session.toJson();
 
     final CollectionReference sessionRef = db.collection(
-        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/sessionMetadata');
+        'participants/$participantID/cognitive_measures/$taskName/sessions/$sessionID/sessionMetadata');
 
     await sessionRef.doc('sessionMetadata').set(sessionData);
   }
@@ -55,7 +55,7 @@ class FirebaseDB implements DB {
     final Map<String, dynamic> trialMap = trial.toJson();
 
     final CollectionReference trialsRef = db.collection(
-        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/trials');
+        'participants/$participantID/cognitive_measures/$taskName/sessions/$sessionID/trials');
 
     await trialsRef.add(trialMap);
   }
@@ -66,7 +66,7 @@ class FirebaseDB implements DB {
   @override
   Future<void> addTrials({required List<Trial> trials}) async {
     final CollectionReference trialsRef = db.collection(
-        'participants/$participantID/cognitive_tasks/$taskName/sessions/$sessionID/trials');
+        'participants/$participantID/cognitive_measures/$taskName/sessions/$sessionID/trials');
 
     final WriteBatch batch = db.batch();
 

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -28,7 +28,7 @@ class FirebaseDB implements DB {
     final Map<String, dynamic> deviceData = device.toJson();
 
     final CollectionReference deviceRef = db.collection(
-        'participants/$participantID/cognitive_measures/$taskName/sessions/$sessionID/deviceMetadata');
+        'cognitive_measures/$taskName/participants/$participantID/sessions/$sessionID/deviceMetadata');
 
     await deviceRef.doc('deviceMetadata').set(deviceData);
   }
@@ -42,7 +42,7 @@ class FirebaseDB implements DB {
     final Map<String, dynamic> sessionData = session.toJson();
 
     final CollectionReference sessionRef = db.collection(
-        'participants/$participantID/cognitive_measures/$taskName/sessions/$sessionID/sessionMetadata');
+        'cognitive_measures/$taskName/participants/$participantID/sessions/$sessionID/sessionMetadata');
 
     await sessionRef.doc('sessionMetadata').set(sessionData);
   }
@@ -55,7 +55,7 @@ class FirebaseDB implements DB {
     final Map<String, dynamic> trialMap = trial.toJson();
 
     final CollectionReference trialsRef = db.collection(
-        'participants/$participantID/cognitive_measures/$taskName/sessions/$sessionID/trials');
+        'cognitive_measures/$taskName/participants/$participantID/sessions/$sessionID/trials');
 
     await trialsRef.add(trialMap);
   }
@@ -66,7 +66,7 @@ class FirebaseDB implements DB {
   @override
   Future<void> addTrials({required List<Trial> trials}) async {
     final CollectionReference trialsRef = db.collection(
-        'participants/$participantID/cognitive_measures/$taskName/sessions/$sessionID/trials');
+        'cognitive_measures/$taskName/participants/$participantID/sessions/$sessionID/trials');
 
     final WriteBatch batch = db.batch();
 

--- a/test/databases/firebase_db/firebase_db_test.dart
+++ b/test/databases/firebase_db/firebase_db_test.dart
@@ -19,7 +19,7 @@ void main() {
       taskName: 'dsb',
     );
     currentSessionPath =
-        'participants/${db.participantID}/cognitive_tasks/${db.taskName}/sessions/${db.sessionID}';
+        'cognitive_measures/${db.taskName}/participants/${db.participantID}/sessions/${db.sessionID}';
   });
 
   test(


### PR DESCRIPTION
## Description

Required changing the order of some of the collection/documents in firebase.

This structure prioritizes cognitive task and not the participant. It aligns better with the traditional structure of data from cognitive measures, where there is a table for each task with the data from all participants.

## Related Issue

Close #82

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
