### PR TITLE
Handle trial timestamps to identify start and end times

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -83,6 +83,8 @@ class MyHomePage extends StatelessWidget {
                   trialType: TrialType.practice,
                   stim: '123',
                   response: '321',
+                  startTime: DateTime.now(),
+                  endTime: DateTime.now(),
                 );
 
                 await _db.addTrial(trial: trial);
@@ -97,6 +99,8 @@ class MyHomePage extends StatelessWidget {
                   trialType: TrialType.practice,
                   stim: '123',
                   response: '321',
+                  startTime: DateTime.now(),
+                  endTime: DateTime.now(),
                 );
                 final Trial trial2 = Trial(
                   participantID: _db.participantID,
@@ -104,6 +108,8 @@ class MyHomePage extends StatelessWidget {
                   trialType: TrialType.practice,
                   stim: '456',
                   response: '654',
+                  startTime: DateTime.now(),
+                  endTime: DateTime.now(),
                 );
                 final List<Trial> trials = <Trial>[trial1, trial2];
 

--- a/lib/models/trial.dart
+++ b/lib/models/trial.dart
@@ -45,7 +45,8 @@ class Trial {
   @override
   String toString() {
     return "Trial(participantID: $participantID, sessionID: $sessionID, "
-        "trialType: $trialType, stim: $stim, response: $response)";
+        "trialType: $trialType, stim: $stim, response: $response, "
+        "startTime: $startTime, endTime: $endTime)";
   }
 
   /// Convert the [Trial] object to its json representation.

--- a/lib/models/trial.dart
+++ b/lib/models/trial.dart
@@ -24,12 +24,20 @@ class Trial {
   /// Response provided by the participant.
   final String response;
 
+  /// Timestamp indicating when the trial started.
+  final DateTime startTime;
+
+  /// Timestamp indicating when the trial ended.
+  final DateTime endTime;
+
   Trial({
     required this.participantID,
     required this.sessionID,
     required TrialType trialType,
     required this.stim,
     required this.response,
+    required this.startTime,
+    required this.endTime,
   }) {
     this.trialType = trialType.name;
   }

--- a/lib/models/trial.g.dart
+++ b/lib/models/trial.g.dart
@@ -12,6 +12,8 @@ Trial _$TrialFromJson(Map<String, dynamic> json) => Trial(
       trialType: $enumDecode(_$TrialTypeEnumMap, json['trialType']),
       stim: json['stim'] as String,
       response: json['response'] as String,
+      startTime: DateTime.parse(json['startTime'] as String),
+      endTime: DateTime.parse(json['endTime'] as String),
     );
 
 Map<String, dynamic> _$TrialToJson(Trial instance) => <String, dynamic>{
@@ -20,6 +22,8 @@ Map<String, dynamic> _$TrialToJson(Trial instance) => <String, dynamic>{
       'trialType': instance.trialType,
       'stim': instance.stim,
       'response': instance.response,
+      'startTime': instance.startTime.toIso8601String(),
+      'endTime': instance.endTime.toIso8601String(),
     };
 
 const _$TrialTypeEnumMap = {

--- a/test/databases/drift_db/drift_db_test.dart
+++ b/test/databases/drift_db/drift_db_test.dart
@@ -23,11 +23,14 @@ void main() {
     "Drift.addTrial correctly inserts a trial into the DriftDB",
     () async {
       final Trial baseTrial = Trial(
-          participantID: '101',
-          sessionID: '001',
-          trialType: TrialType.practice,
-          stim: '456',
-          response: '654');
+        participantID: '101',
+        sessionID: '001',
+        trialType: TrialType.practice,
+        stim: '456',
+        response: '654',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
+      );
 
       await db.addTrial(trial: baseTrial);
 
@@ -49,6 +52,8 @@ void main() {
         trialType: TrialType.practice,
         stim: '123',
         response: '123',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
       );
 
       final Trial trial2 = Trial(
@@ -57,6 +62,8 @@ void main() {
         trialType: TrialType.experimental,
         stim: '456',
         response: '654',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
       );
       final List<Trial> baseTrials = [trial1, trial2];
 

--- a/test/databases/drift_db/models/trial_test.dart
+++ b/test/databases/drift_db/models/trial_test.dart
@@ -20,11 +20,14 @@ void main() {
       'DriftTrial.fromTrial correctly instantiates a DriftTrial object from a base Trial model',
       () {
     final Trial baseTrial = Trial(
-        participantID: '101',
-        sessionID: '001',
-        trialType: TrialType.practice,
-        stim: '456',
-        response: '654');
+      participantID: '101',
+      sessionID: '001',
+      trialType: TrialType.practice,
+      stim: '456',
+      response: '654',
+      startTime: DateTime.now(),
+      endTime: DateTime.now(),
+    );
 
     final DriftTrialsCompanion driftTrial = DriftTrials.fromTrial(baseTrial);
 

--- a/test/databases/firebase_db/firebase_db_test.dart
+++ b/test/databases/firebase_db/firebase_db_test.dart
@@ -72,6 +72,8 @@ void main() {
         trialType: TrialType.practice,
         stim: '456',
         response: '654',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
       );
 
       await db.addTrial(trial: trialLocal);
@@ -94,6 +96,8 @@ void main() {
         trialType: TrialType.practice,
         stim: '123',
         response: '321',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
       );
       final Trial trial2Local = Trial(
         participantID: db.participantID,
@@ -101,6 +105,8 @@ void main() {
         trialType: TrialType.practice,
         stim: '456',
         response: '654',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
       );
 
       final List<Trial> trialsLocal = <Trial>[trial1Local, trial2Local];

--- a/test/databases/in_memory_db_test.dart
+++ b/test/databases/in_memory_db_test.dart
@@ -46,6 +46,8 @@ void main() {
       trialType: TrialType.practice,
       stim: '987',
       response: '987',
+      startTime: DateTime.now(),
+      endTime: DateTime.now(),
     );
     final InMemoryDB inMemoryDB = InMemoryDB();
 
@@ -68,6 +70,8 @@ void main() {
         trialType: TrialType.practice,
         stim: '123',
         response: '123',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
       );
 
       final Trial trial2 = Trial(
@@ -76,6 +80,8 @@ void main() {
         trialType: TrialType.experimental,
         stim: '456',
         response: '654',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
       );
 
       final List<Trial> trials = [trial1, trial2];

--- a/test/models/trial_test.dart
+++ b/test/models/trial_test.dart
@@ -10,11 +10,15 @@ void main() {
       trialType: TrialType.practice,
       stim: 'stimuli',
       response: 'participant response',
+      startTime: DateTime.now(),
+      endTime: DateTime.now(),
     );
     final String strRep =
         "Trial(participantID: ${trial.participantID}, sessionID: ${trial.sessionID}, "
         "trialType: ${trial.trialType}, stim: ${trial.stim}, "
-        "response: ${trial.response})";
+        "response: ${trial.response}, "
+        "startTime: ${trial.startTime}, "
+        "endTime: ${trial.endTime})";
     expect(trial.toString(), strRep);
   });
 
@@ -27,9 +31,12 @@ void main() {
         trialType: TrialType.practice,
         stim: 'stimuli',
         response: 'participant response',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
       );
 
       final Map<String, dynamic> trialJson = trial.toJson();
+      print(trialJson);
 
       expect(trialJson, isMap);
     },

--- a/test/models/trial_test.dart
+++ b/test/models/trial_test.dart
@@ -36,7 +36,6 @@ void main() {
       );
 
       final Map<String, dynamic> trialJson = trial.toJson();
-      print(trialJson);
 
       expect(trialJson, isMap);
     },


### PR DESCRIPTION
## Description

These changes support timestamps for Trial objects to allow collecting data that can be used to calculate response times. 

It is supportted by all instances of dbs.

## Related Issue

Closes #88

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
