### PR TITLE
Refactor access to firebase collections and docs

### DIFF
--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -47,8 +47,14 @@ class FirebaseDB implements DB {
   Future<void> addSession({required Session session}) async {
     final Map<String, dynamic> sessionData = session.toJson();
 
-    final CollectionReference sessionRef = db.collection(
-        'cognitive_measures/$taskName/participants/$participantID/sessions/$sessionID/session');
+    final CollectionReference sessionRef = db
+        .collection('cognitive_measures')
+        .doc(taskName)
+        .collection('participants')
+        .doc(participantID)
+        .collection('sessions')
+        .doc(sessionID)
+        .collection('session');
 
     await sessionRef.doc('session').set(sessionData);
   }

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -66,8 +66,14 @@ class FirebaseDB implements DB {
   Future<void> addTrial({required Trial trial}) async {
     final Map<String, dynamic> trialMap = trial.toJson();
 
-    final CollectionReference trialsRef = db.collection(
-        'cognitive_measures/$taskName/participants/$participantID/sessions/$sessionID/trials');
+    final CollectionReference trialsRef = db
+        .collection('cognitive_measures')
+        .doc(taskName)
+        .collection('participants')
+        .doc(participantID)
+        .collection('sessions')
+        .doc(sessionID)
+        .collection('trials');
 
     await trialsRef.add(trialMap);
   }

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -27,8 +27,14 @@ class FirebaseDB implements DB {
   Future<void> addDevice({required Device device}) async {
     final Map<String, dynamic> deviceData = device.toJson();
 
-    final CollectionReference deviceRef = db.collection(
-        'cognitive_measures/$taskName/participants/$participantID/sessions/$sessionID/device');
+    final CollectionReference deviceRef = db
+        .collection('cognitive_measures')
+        .doc(taskName)
+        .collection('participants')
+        .doc(participantID)
+        .collection('sessions')
+        .doc(sessionID)
+        .collection('device');
 
     await deviceRef.doc('device').set(deviceData);
   }

--- a/lib/databases/firebase_db/firebase_db.dart
+++ b/lib/databases/firebase_db/firebase_db.dart
@@ -83,8 +83,14 @@ class FirebaseDB implements DB {
   /// named `trials`.
   @override
   Future<void> addTrials({required List<Trial> trials}) async {
-    final CollectionReference trialsRef = db.collection(
-        'cognitive_measures/$taskName/participants/$participantID/sessions/$sessionID/trials');
+    final CollectionReference trialsRef = db
+        .collection('cognitive_measures')
+        .doc(taskName)
+        .collection('participants')
+        .doc(participantID)
+        .collection('sessions')
+        .doc(sessionID)
+        .collection('trials');
 
     final WriteBatch batch = db.batch();
 


### PR DESCRIPTION
## Description

Use methods provided by firebase to access collections and docs (e.g., `collection()`) instead of specifying the full path as a string.

## Related Issue

Closes #90

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
